### PR TITLE
Updated "HQ Geometry Shaders" (better formatting), fixed outdated "u_position()" for R2.

### DIFF
--- a/res/gamedata/shaders/r2/skin.h
+++ b/res/gamedata/shaders/r2/skin.h
@@ -49,7 +49,7 @@ struct 	v_model_skinned_4		// 28 bytes
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
-float4 	u_position	(float4 v)	{ return float4(v.xyz*(12.f / 32768.f), 1.f);	}	// -12..+12
+float4 	u_position	(float4 v)	{ return float4(v.xyz, 1.f);	}	// -12..+12
 
 //////////////////////////////////////////////////////////////////////////////////////////
 //uniform float4 	sbones_array	[256-22] : register(vs,c22);


### PR DESCRIPTION
Current skin.h for R2 have vanilla "u_position" function, so OpenXRay can't detect it as HQ-geometry shader